### PR TITLE
网站ajax初步完成

### DIFF
--- a/src/main/webapp/WEB-INF/jspf/mobile/header.jspf
+++ b/src/main/webapp/WEB-INF/jspf/mobile/header.jspf
@@ -8,8 +8,6 @@
 <link href="/resources/css/wap.css" rel="stylesheet" type="text/css"/>
 
 <script type="text/javascript" src="http://apps.bdimg.com/libs/jquery/2.1.4/jquery.min.js" ></script>
-<script type="text/javascript" src="/resources/web/js/jquery.corner.js"></script>
-<script type="text/javascript" src="/resources/web/js/corner.js"></script>
 <script type="text/javascript" src="/resources/web/js/baseCookie.js"></script>
 <div id='wx_pic' style='margin:0 auto;display:none;'>
     <img alt="logo" src="/resources/mobile/images/logo_300x300.jpg"/>

--- a/src/main/webapp/mobile/video/view.jsp
+++ b/src/main/webapp/mobile/video/view.jsp
@@ -56,5 +56,7 @@
 <!--页脚部分 -->
 <%@include file="/WEB-INF/jspf/mobile/footer.jspf" %>
 <!--页脚部分结束 -->
+<script>app.videoView();
+</script>
 </body>
 </html>

--- a/src/main/webapp/resources/js/mobile.js
+++ b/src/main/webapp/resources/js/mobile.js
@@ -113,7 +113,7 @@ var app = {
         if (play) {
           $('#video-player').attr('src', 'http://v3.yidumen.com/video/360/' + data[0].file + '_360.mp4');
           $('#video-switcher').append('<li><a href="http://v3.yidumen.com/video/720/' + data[0].file + '_720.mp4">超清</a></li>')
-            .append('<li><a href="http://v3.yidumen.com/video/480/' + data[0].file + '_720.mp4">高清</a></li>')
+            .append('<li><a href="http://v3.yidumen.com/video/480/' + data[0].file + '_480.mp4">高清</a></li>')
             .append('<li id="active"><a href="http://v3.yidumen.com/video/360/' + data[0].file + '_360.mp4">标清</a></li>')
             .append('<li><a href="http://v3.yidumen.com/video/180/' + data[0].file + '_180.mp4">流畅</a></li>')
         }
@@ -143,6 +143,10 @@ var app = {
     };
     $(window).scroll(scrollListen);
     result.resolve(videos);
+    $('#video-switcher').on('click', 'li>a', function (event) {
+      $('#video-player').attr('src', $(this).attr('href'));
+      return false;
+    })
   },
   chatroom: function () {
     this.videoList(true);
@@ -153,19 +157,12 @@ var app = {
   },
   videoView: function () {
     $.getJSON('/ajax/video/' + this.pathValue()).done(function (data) {
-      var videos = [];
-      videos.push(data);
-      videojs("video-player", {
-        "controls": true,
-        "autoplay": true,
-        "width": "100%",
-        "height": "100%",
-        plugins: {
-          ydmPlayer: {
-            videos: videos
-          }
-        }
-      });
+      $('#video-player').attr('src', 'http://v3.yidumen.com/video/360/' + data.file + '_360.mp4');
+      $('#video-switcher').append('<li><a href="http://v3.yidumen.com/video/720/' + data.file + '_720.mp4">超清</a></li>')
+        .append('<li><a href="http://v3.yidumen.com/video/480/' + data.file + '_480.mp4">高清</a></li>')
+        .append('<li id="active"><a href="http://v3.yidumen.com/video/360/' + data.file + '_360.mp4">标清</a></li>')
+        .append('<li><a href="http://v3.yidumen.com/video/180/' + data.file + '_180.mp4">流畅</a></li>')
+
     });
     this.videoList(false);
   },


### PR DESCRIPTION
1. 持久层去掉`Hibernate`，改成直接用`Spring JDBC`，自己实现简单的ORM映射；
2. 桌面版视频请求、聊天室列表换成`ajax`
3. 移动版聊天室页面换成`ajax`，其它页面暂时保持原样。

下一步：
 * 前端开发引入node管理，使用gulp管理js和css?
 * 清理js文件，采用合并压缩的方式引入页面？
 * 转换css为less格式，采用合并压缩的方式引入页面？